### PR TITLE
OAuth support for MFA

### DIFF
--- a/auroraplus/__init__.py
+++ b/auroraplus/__init__.py
@@ -10,6 +10,7 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import Timeout
 from requests_oauthlib import OAuth2Session
 
+from .get_token import get_token
 
 class api:
     '''

--- a/auroraplus/__init__.py
+++ b/auroraplus/__init__.py
@@ -141,7 +141,7 @@ class api:
             hashlib.sha256(self.code_verifier.encode()).digest()
         ).strip(b'=')
 
-        authorization_url, _ = self.session.authorization_url(
+        self.authorization_url, _ = self.session.authorization_url(
             self.AUTHORIZE_URL,
             client_request_id=uuid.uuid4(),
             client_info=1,
@@ -149,7 +149,7 @@ class api:
             code_challenge_method='S256',
             state=base64.encodebytes(json.dumps(state).encode()))
 
-        return authorization_url
+        return self.authorization_url
 
     def oauth_redirect(self, authorization_response: str):
         """
@@ -180,6 +180,36 @@ class api:
             authorization_response=authorization_response,
             code_verifier=self.code_verifier,
         )
+
+    def oauth_dump(self) -> dict:
+        """
+        Export partial OAuth state, for use in asynchronous or request/response-based
+        workflows.
+
+        Returns:
+        --------
+
+        dict: a dict of all the relevant state
+        """
+        return {
+            'authorization_url': self.authorization_url,
+            'code_verifier': self.code_verifier,
+        }
+
+    def oauth_load(self,
+                   authorization_url: str,
+                   code_verifier: str,
+                   ):
+        """
+        Import partial OAuth state.
+
+        Params:
+        -------
+
+        kwargs: pass the state dict returned from oauth_dump.
+        """
+        self.authorization_url = authorization_url
+        self.code_verifier = code_verifier
 
     def _include_access_token(self, r) -> dict:
         """

--- a/auroraplus/__init__.py
+++ b/auroraplus/__init__.py
@@ -1,4 +1,5 @@
 """Abstraction of the Aurora+ API"""
+
 import base64
 import hashlib
 import json
@@ -12,8 +13,9 @@ from requests_oauthlib import OAuth2Session
 
 from .get_token import get_token
 
+
 class api:
-    '''
+    """
     A client to interact with the Aurora+ API.
 
     Obtaining a new OAuth token is done in two steps:
@@ -43,24 +45,25 @@ class api:
         >>> api.day
         {'StartDate': '2023-12-25T13:00:00Z', 'EndDate': '2023-12-26T13:00:00Z', 'TimeMeasureCount': 1, ...
 
-    '''
-    USER_AGENT = 'python/auroraplus'
+    """
 
-    OAUTH_BASE_URL = 'https://customers.auroraenergy.com.au' \
-        '/auroracustomers1p.onmicrosoft.com/b2c_1a_sign_in/'
-    AUTHORIZE_URL = OAUTH_BASE_URL + '/oauth2/v2.0/authorize'
-    TOKEN_URL = OAUTH_BASE_URL + '/oauth2/v2.0/token'
-    CLIENT_ID = '2ff9da64-8629-4a92-a4b6-850a3f02053d'
-    REDIRECT_URI = 'https://my.auroraenergy.com.au/login/redirect'
+    USER_AGENT = "python/auroraplus"
 
-    API_URL = 'https://api.auroraenergy.com.au/api'
-    BEARER_TOKEN_URL = API_URL + '/identity/LoginToken'
+    OAUTH_BASE_URL = (
+        "https://customers.auroraenergy.com.au"
+        "/auroracustomers1p.onmicrosoft.com/b2c_1a_sign_in/"
+    )
+    AUTHORIZE_URL = OAUTH_BASE_URL + "/oauth2/v2.0/authorize"
+    TOKEN_URL = OAUTH_BASE_URL + "/oauth2/v2.0/token"
+    CLIENT_ID = "2ff9da64-8629-4a92-a4b6-850a3f02053d"
+    REDIRECT_URI = "https://my.auroraenergy.com.au/login/redirect"
 
-    SCOPE = ['openid', 'profile', 'offline_access']
+    API_URL = "https://api.auroraenergy.com.au/api"
+    BEARER_TOKEN_URL = API_URL + "/identity/LoginToken"
 
-    def __init__(self,
-                 username: str = None, password: str = None,
-                 token: dict = None):
+    SCOPE = ["openid", "profile", "offline_access"]
+
+    def __init__(self, username: str = None, password: str = None, token: dict = None):
         """Initialise the API.
 
         An authenticated object can be recreated from a preexisting OAuth `token` with
@@ -93,7 +96,7 @@ class api:
         if not token and password and not username:
             # Backward compatibility: if no username and no token,
             # assume the password is a bearer access token
-            token = {'access_token': password, 'token_type': 'bearer'}
+            token = {"access_token": password, "token_type": "bearer"}
             backward_compat = True
         self.token = token
         api_adapter = HTTPAdapter(max_retries=2)
@@ -103,15 +106,17 @@ class api:
             self.CLIENT_ID,
             redirect_uri=self.REDIRECT_URI,
             scope=self.SCOPE,
-            token=token
+            token=token,
         )
         session.mount(self.API_URL, api_adapter)
-        session.headers.update({
-            'Accept': 'application/json',
-            'User-Agent': self.USER_AGENT,
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Connection': 'keep-alive',
-        })
+        session.headers.update(
+            {
+                "Accept": "application/json",
+                "User-Agent": self.USER_AGENT,
+                "Accept-Encoding": "gzip, deflate, br",
+                "Connection": "keep-alive",
+            }
+        )
         self.session = session
 
         if backward_compat and self.token:
@@ -132,22 +137,24 @@ class api:
             "meta": {"interactionType": "redirect"},
         }
 
-        self.code_verifier = ''.join([random.choice(
-            string.ascii_letters
-            + string.digits
-            + '-_')
-            for i in range(43)])
+        self.code_verifier = "".join(
+            [
+                random.choice(string.ascii_letters + string.digits + "-_")
+                for i in range(43)
+            ]
+        )
         code_challenge = base64.urlsafe_b64encode(
             hashlib.sha256(self.code_verifier.encode()).digest()
-        ).strip(b'=')
+        ).strip(b"=")
 
         self.authorization_url, _ = self.session.authorization_url(
             self.AUTHORIZE_URL,
             client_request_id=uuid.uuid4(),
             client_info=1,
             code_challenge=code_challenge,
-            code_challenge_method='S256',
-            state=base64.encodebytes(json.dumps(state).encode()))
+            code_challenge_method="S256",
+            state=base64.encodebytes(json.dumps(state).encode()),
+        )
 
         return self.authorization_url
 
@@ -170,10 +177,10 @@ class api:
         dict: full token information
 
         """
-        if not self.session.compliance_hook['access_token_response']:
+        if not self.session.compliance_hook["access_token_response"]:
             self.session.register_compliance_hook(
-                'access_token_response',
-                self._include_access_token)
+                "access_token_response", self._include_access_token
+            )
 
         return self.session.fetch_token(
             self.TOKEN_URL,
@@ -192,14 +199,15 @@ class api:
         dict: a dict of all the relevant state
         """
         return {
-            'authorization_url': self.authorization_url,
-            'code_verifier': self.code_verifier,
+            "authorization_url": self.authorization_url,
+            "code_verifier": self.code_verifier,
         }
 
-    def oauth_load(self,
-                   authorization_url: str,
-                   code_verifier: str,
-                   ):
+    def oauth_load(
+        self,
+        authorization_url: str,
+        code_verifier: str,
+    ):
         """
         Import partial OAuth state.
 
@@ -222,17 +230,17 @@ class api:
         dict: the full token
         """
         rjs = r.json()
-        id_token = rjs.get('id_token')
+        id_token = rjs.get("id_token")
 
-        atr = self.session.post(self.BEARER_TOKEN_URL,
-                                json={'token': id_token}
-                                )
-        access_token = atr.json().get('accessToken')
+        atr = self.session.post(self.BEARER_TOKEN_URL, json={"token": id_token})
+        access_token = atr.json().get("accessToken")
 
-        rjs.update({
-            'access_token': access_token.split()[1],
-            'scope': 'openid profile offline_access',
-        })
+        rjs.update(
+            {
+                "access_token": access_token.split()[1],
+                "scope": "openid profile offline_access",
+            }
+        )
 
         r._content = json.dumps(rjs).encode()
 
@@ -247,23 +255,21 @@ class api:
     def get_info(self):
         """Get CustomerID and ServiceAgreementID"""
         try:
-            r = self.session.get(
-                self.API_URL + '/customers/current'
-            )
+            r = self.session.get(self.API_URL + "/customers/current")
             r.raise_for_status()
             current = r.json()[0]
-            self.customerId = current['CustomerID']
+            self.customerId = current["CustomerID"]
 
             """Loop through premises to get active """
-            premises = current['Premises']
+            premises = current["Premises"]
             for premise in premises:
-                if (premise['ServiceAgreementStatus'] == 'Active'):
-                    self.Active = premise['ServiceAgreementStatus']
-                    self.serviceAgreementID = premise['ServiceAgreementID']
-            if (self.Active != 'Active'):
-                self.Error = 'No active premise found'
+                if premise["ServiceAgreementStatus"] == "Active":
+                    self.Active = premise["ServiceAgreementStatus"]
+                    self.serviceAgreementID = premise["ServiceAgreementID"]
+            if self.Active != "Active":
+                self.Error = "No active premise found"
         except Timeout:
-            self.Error = 'Info request timed out'
+            self.Error = "Info request timed out"
 
     def request(self, timespan, index=-1):
         if not self.serviceAgreementID:
@@ -271,26 +277,26 @@ class api:
         try:
             request = self.session.get(
                 self.API_URL
-                + '/usage/'
+                + "/usage/"
                 + timespan
-                + '?serviceAgreementID='
+                + "?serviceAgreementID="
                 + self.serviceAgreementID
-                + '&customerId='
+                + "&customerId="
                 + self.customerId
-                + '&index='
+                + "&index="
                 + str(index)
             )
-            if (request.status_code == 200):
+            if request.status_code == 200:
                 return request.json()
             else:
-                self.Error = 'Data request failed: ' + request.reason
+                self.Error = "Data request failed: " + request.reason
         except Timeout:
-            self.Error = 'Data request timed out'
+            self.Error = "Data request timed out"
 
     def getsummary(self, index=-1):
         summarydata = self.request("day", index)
-        self.DollarValueUsage = summarydata['SummaryTotals']['DollarValueUsage']
-        self.KilowattHourUsage = summarydata['SummaryTotals']['KilowattHourUsage']
+        self.DollarValueUsage = summarydata["SummaryTotals"]["DollarValueUsage"]
+        self.KilowattHourUsage = summarydata["SummaryTotals"]["KilowattHourUsage"]
 
     def getday(self, index=-1):
         self.day = self.request("day", index)
@@ -310,31 +316,37 @@ class api:
     def getcurrent(self):
         try:
             """Request current customer data"""
-            current = self.session.get(
-                self.API_URL + '/customers/current'
-            )
+            current = self.session.get(self.API_URL + "/customers/current")
 
-            if (current.status_code == 200):
+            if current.status_code == 200:
                 currentjson = current.json()[0]
 
                 """Loop through premises to match serviceAgreementID already found in token request"""
-                premises = currentjson['Premises']
-                found = ''
+                premises = currentjson["Premises"]
+                found = ""
                 for premise in premises:
-                    if (premise['ServiceAgreementID'] == self.serviceAgreementID):
-                        found = 'true'
-                        self.AmountOwed = "{:.2f}".format(premise['AmountOwed'])
-                        self.EstimatedBalance = "{:.2f}".format(premise['EstimatedBalance'])
-                        self.AverageDailyUsage = "{:.2f}".format(premise['AverageDailyUsage'])
-                        self.UsageDaysRemaining = premise['UsageDaysRemaining']
-                        self.ActualBalance = "{:.2f}".format(premise['ActualBalance'])
-                        self.UnbilledAmount = "{:.2f}".format(premise['UnbilledAmount'])
-                        self.BillTotalAmount = "{:.2f}".format(premise['BillTotalAmount'])
-                        self.NumberOfUnpaidBills = premise['NumberOfUnpaidBills']
-                        self.BillOverDueAmount = "{:.2f}".format(premise['BillOverDueAmount'])
-                if (found != 'true'):
-                    self.Error = 'ServiceAgreementID not found'
+                    if premise["ServiceAgreementID"] == self.serviceAgreementID:
+                        found = "true"
+                        self.AmountOwed = "{:.2f}".format(premise["AmountOwed"])
+                        self.EstimatedBalance = "{:.2f}".format(
+                            premise["EstimatedBalance"]
+                        )
+                        self.AverageDailyUsage = "{:.2f}".format(
+                            premise["AverageDailyUsage"]
+                        )
+                        self.UsageDaysRemaining = premise["UsageDaysRemaining"]
+                        self.ActualBalance = "{:.2f}".format(premise["ActualBalance"])
+                        self.UnbilledAmount = "{:.2f}".format(premise["UnbilledAmount"])
+                        self.BillTotalAmount = "{:.2f}".format(
+                            premise["BillTotalAmount"]
+                        )
+                        self.NumberOfUnpaidBills = premise["NumberOfUnpaidBills"]
+                        self.BillOverDueAmount = "{:.2f}".format(
+                            premise["BillOverDueAmount"]
+                        )
+                if found != "true":
+                    self.Error = "ServiceAgreementID not found"
             else:
-                self.Error = 'Current request failed: ' + current.reason
+                self.Error = "Current request failed: " + current.reason
         except Timeout:
-            self.Error = 'Current request timed out'
+            self.Error = "Current request timed out"

--- a/auroraplus/get_token.py
+++ b/auroraplus/get_token.py
@@ -1,0 +1,28 @@
+#!/bin/env python
+
+import auroraplus
+
+
+def get_token():
+    api = auroraplus.api()
+    url = api.oauth_authorize()
+
+    print("Please visit the following URL in a browser, "
+          "and follow the login prompts ...\n")
+    print(url)
+
+    print("\nThis will redirect to an error page (Cradle Mountain).\n")
+
+    redirect_uri = input("Please enter the full URL of the error page: ")
+
+    token = api.oauth_redirect(redirect_uri)
+
+    print("\nThe new token is\n")
+    print(token)
+
+    print("\n The access token is\n")
+    print(token['access_token'])
+
+
+if __name__ == "__main__":
+    get_token()

--- a/auroraplus/get_token.py
+++ b/auroraplus/get_token.py
@@ -7,8 +7,10 @@ def get_token():
     api = auroraplus.api()
     url = api.oauth_authorize()
 
-    print("Please visit the following URL in a browser, "
-          "and follow the login prompts ...\n")
+    print(
+        "Please visit the following URL in a browser, "
+        "and follow the login prompts ...\n"
+    )
     print(url)
 
     print("\nThis will redirect to an error page (Cradle Mountain).\n")
@@ -21,7 +23,7 @@ def get_token():
     print(token)
 
     print("\n The access token is\n")
-    print(token['access_token'])
+    print(token["access_token"])
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,11 @@ AuroraPlus is a package to pull data from https://api.auroraenergy.com.au/api. T
 
 ### Obtain a token
 
-Obtaining a token is an interactive process where the user needs to log on to
-the AuroraPlus web application.
+The easieast way to obtain a new token is to use the `auroraplus_get_token`
+script.
+
+To do this more programatically, obtaining a token is an interactive process
+where the user needs to log on to the AuroraPlus web application.
 
     >>> import auroraplus
     >>> api = auroraplus.api()

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,42 @@ AuroraPlus is a package to pull data from https://api.auroraenergy.com.au/api. T
 
 ## Usage
 
-Connect to Aurora+ API:
+### Obtain a token
+
+Obtaining a token is an interactive process where the user needs to log on to
+the AuroraPlus web application.
+
+    >>> import auroraplus
+    >>> api = auroraplus.api()
+    >>> api.oauth_authorize()
+    'https://customers.auroraenergy.com.au/auroracustomers1p.onmicrosoft.com/b2c_1a_sign_in//oauth2/v2.0/authorize?response_type=code&client_id=2ff9da64-8629-4a92-a4b6-850a3f02053d&redirect_uri=https%3A%2F%2Fmy.auroraenergy.coom.au%2Flogin%2Fredirect&scope=openid+profile+offline_access&state=...&client_info=1'
+
+Follow the URL above in a browser to authenticate with username+password and
+MFA. This will redirect to an error page (Cradle Mountain). Copy the full URL,
+of the error page and continue.
+
+    >>> api.oauth_redirect('https://my.auroraenergy.com.au/login/redirect?state=...')
+    {'id_token': 'ey...', 'access_token': 'ey...', 'token_type': 'bearer', ...}
+
+The `api` object is now ready to use (start with `api.get_info()`. The token
+returned in the last step can be saved for later use when re-initialising the
+`api` object without having to follow the OAuth flow to obtain a new
+authorisation.
+
+### Connect to Aurora+ API with a pre-issued token
 
     import auroraplus
     AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
     AuroraPlus.get_info()
 
-To get current account information use the following:
+For backward compatibility with users of the login/password method, the
+`access_token` can be passed as the `password` if the `user` is empty.
+
+    import auroraplus
+    AuroraPlus = auroraplus.api(password=<ACCESS_TOKEN>)
+    AuroraPlus.get_info()
+
+### Get current account information
 
     AuroraPlus.getcurrent()
 
@@ -43,7 +72,7 @@ An example getting specific data with getcurrent:
     else:
         print(AuroraPlus.Error)
         
-To get summary usage information use the following:
+### Get summary usage information
 
     AuroraPlus.getsummary()
     
@@ -68,7 +97,9 @@ An example getting specific data with getsummary:
         
     Note: Offpeak tarrifs not listed
 
-To get usage data use the following, this returns all available data in json format for each timespan:
+### Get usage data use the following
+
+The following returns all available data in json format for each timespan:
 
     AuroraPlus.getday()
     AuroraPlus.getweek()

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,8 @@ AuroraPlus is a package to pull data from https://api.auroraenergy.com.au/api. T
 Connect to Aurora+ API:
 
     import auroraplus
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
 
 To get current account information use the following:
 
@@ -34,7 +35,8 @@ getcurrent() gets the following data:
 An example getting specific data with getcurrent:
 
     import auroraplus
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
     if (not AuroraPlus.Error):
         AuroraPlus.getcurrent()
         print(AuroraPlus.AmountOwed)
@@ -50,7 +52,8 @@ To get summary usage information use the following:
 An example getting specific data with getsummary:
 
     import auroraplus
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
     if (not AuroraPlus.Error):
         AuroraPlus.getsummary()
         print(AuroraPlus.DollarValueUsage['T41'])
@@ -75,7 +78,8 @@ To get usage data use the following, this returns all available data in json for
 
 Full example:
 
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
     if (not AuroraPlus.Error):
         AuroraPlus.getcurrent()
         print(AuroraPlus.AmountOwed)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 # Inside of setup.cfg
 [metadata]
-description_file = README.md
+description_file = readme.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 # Inside of setup.cfg
 [metadata]
 description_file = readme.md
+
+[options.entry_points]
+console_scripts =
+  auroraplus_get_token = auroraplus:get_token

--- a/setup.py
+++ b/setup.py
@@ -2,109 +2,17 @@ from setuptools import setup
 from distutils.core import setup
 from os import path
 
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "readme.md").read_text()
+
 setup(
     name='auroraplus',
     packages=['auroraplus'],
     version='1.1.6',
     license='MIT',
     description='Python library to access the Aurora+ API: https://api.auroraenergy.com.au/api',
-    long_description="""AuroraPlus is a package to pull data from https://api.auroraenergy.com.au/api. To use the Aurora+ API you need a valid account with Aurora.
-
-## Requirements
-- Install Python 3.9 (for all users)
-- Pip install requests
-
-## Usage
-
-Connect to Aurora+ API:
-
-    import auroraplus
-    AuroraPlus = auroraplus.api(token)
-    AuroraPlus.get_info()
-
-To get current account information use the following:
-
-    AuroraPlus.getcurrent()
-
-getcurrent() gets the following data:
-
-    EstimatedBalance - This is shown in the Aurora+ app as 'Balance'
-    UsageDaysRemaining - This is shown in the Aurora+ app as 'Days Prepaid'
-    AverageDailyUsage
-    AmountOwed
-    ActualBalance
-    UnbilledAmount
-    BillTotalAmount
-    NumberOfUnpaidBills
-    BillOverDueAmount
-    
-    Note: All data except AverageDailyUsage is updated Daily.
-
-An example getting specific data with getcurrent:
-
-    import auroraplus
-    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
-    AuroraPlus.get_info()
-    if (not AuroraPlus.Error):
-        AuroraPlus.getcurrent()
-        print(AuroraPlus.AmountOwed)
-    else:
-        print(AuroraPlus.Error)
-        
-To get summary usage information use the following:
-
-    AuroraPlus.getsummary()
-    
-    Note: This returns two collections, DollarValueUsage and KilowattHourUsage.
-    
-An example getting specific data with getsummary:
-
-    import auroraplus
-    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
-    AuroraPlus.get_info()
-    if (not AuroraPlus.Error):
-        AuroraPlus.getsummary()
-        print(AuroraPlus.DollarValueUsage['T41'])
-        print(AuroraPlus.DollarValueUsage['T31'])
-        print(AuroraPlus.DollarValueUsage['Other'])
-        print(AuroraPlus.DollarValueUsage['Total'])
-        print(AuroraPlus.KilowattHourUsage['T41'])
-        print(AuroraPlus.KilowattHourUsage['T31'])
-        print(AuroraPlus.KilowattHourUsage['Total'])
-    else:
-        print(AuroraPlus.Error)
-        
-    Note: Offpeak tarrifs not listed
-
-To get usage data use the following, this returns all available data in json format for each timespan:
-
-    AuroraPlus.getday()
-    AuroraPlus.getweek()
-    AuroraPlus.getmonth()
-    AuroraPlus.getquarter()
-    AuroraPlus.getyear()
-
-Full example:
-
-    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
-    AuroraPlus.get_info()
-    if (not AuroraPlus.Error):
-        AuroraPlus.getcurrent()
-        print(AuroraPlus.AmountOwed)
-        
-        AuroraPlus.getday()
-        print(AuroraPlus.day)
-        
-        AuroraPlus.getweek()
-        print(AuroraPlus.week)
-        
-        AuroraPlus.getmonth()
-        print(AuroraPlus.month
-        
-        AuroraPlus.getyear()
-        print(AuroraPlus.year)
-    else:
-        print(AuroraPlus.Error)""",
+    long_description=long_description,
     long_description_content_type='text/markdown',
     author='Leigh Curran',
     author_email='AuroraPlusPy@outlook.com',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     url='https://github.com/leighcurran/AuroraPlus',
     keywords=['Aurora+', 'AuroraPlus', 'Aurora', 'Tasmania', 'API'],
     install_requires=[
+        'brotli',
         'requests',
         'requests_oauthlib',
     ],

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from distutils.core import setup
 from os import path
 
 setup(
-  name = 'auroraplus',
-  packages = ['auroraplus'],
-  version = '1.1.6',
-  license='MIT',
-  description = 'Python library to access the Aurora+ API: https://api.auroraenergy.com.au/api',
-  long_description="""AuroraPlus is a package to pull data from https://api.auroraenergy.com.au/api. To use the Aurora+ API you need a valid account with Aurora.
+    name='auroraplus',
+    packages=['auroraplus'],
+    version='1.1.6',
+    license='MIT',
+    description='Python library to access the Aurora+ API: https://api.auroraenergy.com.au/api',
+    long_description="""AuroraPlus is a package to pull data from https://api.auroraenergy.com.au/api. To use the Aurora+ API you need a valid account with Aurora.
 
 ## Requirements
 - Install Python 3.9 (for all users)
@@ -19,7 +19,8 @@ setup(
 Connect to Aurora+ API:
 
     import auroraplus
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token)
+    AuroraPlus.get_info()
 
 To get current account information use the following:
 
@@ -42,7 +43,8 @@ getcurrent() gets the following data:
 An example getting specific data with getcurrent:
 
     import auroraplus
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
     if (not AuroraPlus.Error):
         AuroraPlus.getcurrent()
         print(AuroraPlus.AmountOwed)
@@ -58,7 +60,8 @@ To get summary usage information use the following:
 An example getting specific data with getsummary:
 
     import auroraplus
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
     if (not AuroraPlus.Error):
         AuroraPlus.getsummary()
         print(AuroraPlus.DollarValueUsage['T41'])
@@ -83,7 +86,8 @@ To get usage data use the following, this returns all available data in json for
 
 Full example:
 
-    AuroraPlus = auroraplus.api("user.name@outlook.com", "password")
+    AuroraPlus = auroraplus.api(token={"access_token": "...", "token_type": "bearer"})
+    AuroraPlus.get_info()
     if (not AuroraPlus.Error):
         AuroraPlus.getcurrent()
         print(AuroraPlus.AmountOwed)
@@ -101,23 +105,24 @@ Full example:
         print(AuroraPlus.year)
     else:
         print(AuroraPlus.Error)""",
-  long_description_content_type='text/markdown',
-  author = 'Leigh Curran',
-  author_email = 'AuroraPlusPy@outlook.com',
-  url = 'https://github.com/leighcurran/AuroraPlus',
-  keywords = ['Aurora+', 'AuroraPlus', 'Aurora', 'Tasmania', 'API'],
-  install_requires=[
-          'requests',
-      ],
-  classifiers=[
-    'Development Status :: 3 - Alpha',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
-    'Intended Audience :: Developers',
-    'Topic :: Software Development :: Build Tools',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-  ],
+    long_description_content_type='text/markdown',
+    author='Leigh Curran',
+    author_email='AuroraPlusPy@outlook.com',
+    url='https://github.com/leighcurran/AuroraPlus',
+    keywords=['Aurora+', 'AuroraPlus', 'Aurora', 'Tasmania', 'API'],
+    install_requires=[
+        'requests',
+        'requests_oauthlib',
+    ],
+    classifiers=[
+        'Development Status :: 3 - Alpha',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+    ],
 )


### PR DESCRIPTION
This will fix #2, and is built on top of #1.

~This is a breaking change in the API (replacing `gettoken` with `get_info`), so likely will require something like a new major version.~ It's now backward-compatible.

The token can be provided on `init`, e.g., 

```python
>>> import auroraplus
>>> api = auroraplus.api({'access_token': 'xxx', 'token_type': 'bearer'})
>>> api.get_info()
>>> api.serviceAgreementID
'nnn'
>>> api.getday()
>>> api.day['SummaryTotals']
{'DollarValueUsage': {'Other': 0.0, 'Total': 0.0, 'T140': 0.0, 'T93OFFPEAK': 0.0}, 'KilowattHourUsage': {'Total': 0.0, 'T140': 0.0, 'T93OFFPEAK': 0.0}, 'DayContainsSubstitutedUsage': False, 'HasDailyBillSegments': False}

```

or fetched semi-interactively (wip).